### PR TITLE
fix(exit): add optional "exit" final arg to Parse()

### DIFF
--- a/docopt.go
+++ b/docopt.go
@@ -85,14 +85,24 @@ import (
 //   "<port>": "8"',
 //   "serial": false,
 //   "tcp": true}
-func Parse(doc string, argv []string, help bool, version string, optionsFirst bool) (map[string]interface{}, error) {
+func Parse(doc string, argv []string, help bool, version string,
+	optionsFirst bool, exit ...bool) (map[string]interface{}, error) {
+	// if "false" was the (optional) last arg, don't call os.Exit()
+	exitOk := true
+	if len(exit) > 0 {
+		exitOk = exit[0]
+	}
 	args, output, err := parse(doc, argv, help, version, optionsFirst)
 	if _, ok := err.(*UserError); ok {
 		fmt.Println(output)
-		os.Exit(1)
+		if exitOk {
+			os.Exit(1)
+		}
 	} else if len(output) > 0 && err == nil {
 		fmt.Println(output)
-		os.Exit(0)
+		if exitOk {
+			os.Exit(0)
+		}
 	}
 	return args, err
 }


### PR DESCRIPTION
Users of docopt.go should be able to handle their own return
codes and os.Exit() processing. Calling the Parse() func with
an extra last arg of "false" means docopt.go will not call
os.Exit().

Additionally, the docopt_test.go suite was changed to call the
exported Parse() func instead of the parse() implementation.

Fixes #7.
