### PR TITLE
fix(package): import and "go get" as docopt-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Golang implementation of [docopt](http://docopt.org/) 0.6.1+fix
 
 ## Installation
 
-import "github.com/docopt/docopt.go" and then run `go get`.
+import "github.com/docopt/docopt-go" and then run `go get`.
 
 ## API
 
@@ -45,7 +45,7 @@ package main
 
 import (
     "fmt"
-    "github.com/docopt/docopt.go"
+    "github.com/docopt/docopt-go"
 )
 
 func main() {

--- a/docopt.go
+++ b/docopt.go
@@ -58,7 +58,7 @@ import (
 //
 //  import (
 //      "fmt"
-//      "github.com/docopt/docopt.go"
+//      "github.com/docopt/docopt-go"
 //  )
 //
 //  func main() {

--- a/examples/arguments_example.go
+++ b/examples/arguments_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt.go"
+	"github.com/docopt/docopt-go"
 )
 
 func main() {

--- a/examples/calculator_example.go
+++ b/examples/calculator_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt.go"
+	"github.com/docopt/docopt-go"
 )
 
 func main() {

--- a/examples/config_file_example.go
+++ b/examples/config_file_example.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/docopt/docopt.go"
+	"github.com/docopt/docopt-go"
 	"strings"
 )
 

--- a/examples/counted_example.go
+++ b/examples/counted_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt.go"
+	"github.com/docopt/docopt-go"
 )
 
 func main() {

--- a/examples/git/git.go
+++ b/examples/git/git.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt.go"
+	"github.com/docopt/docopt-go"
 	"os"
 	"os/exec"
 )

--- a/examples/git/git_add.go
+++ b/examples/git/git_add.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt.go"
+	"github.com/docopt/docopt-go"
 )
 
 func cmdAdd(argv []string) (err error) {

--- a/examples/git/git_branch.go
+++ b/examples/git/git_branch.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt.go"
+	"github.com/docopt/docopt-go"
 )
 
 func main() {

--- a/examples/git/git_checkout.go
+++ b/examples/git/git_checkout.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt.go"
+	"github.com/docopt/docopt-go"
 )
 
 func main() {

--- a/examples/git/git_clone.go
+++ b/examples/git/git_clone.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt.go"
+	"github.com/docopt/docopt-go"
 )
 
 func main() {

--- a/examples/git/git_push.go
+++ b/examples/git/git_push.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt.go"
+	"github.com/docopt/docopt-go"
 )
 
 func main() {

--- a/examples/git/git_remote.go
+++ b/examples/git/git_remote.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt.go"
+	"github.com/docopt/docopt-go"
 )
 
 func main() {

--- a/examples/naval_fate.go
+++ b/examples/naval_fate.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt.go"
+	"github.com/docopt/docopt-go"
 )
 
 func main() {

--- a/examples/odd_even_example.go
+++ b/examples/odd_even_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt.go"
+	"github.com/docopt/docopt-go"
 )
 
 func main() {

--- a/examples/options_example.go
+++ b/examples/options_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt.go"
+	"github.com/docopt/docopt-go"
 )
 
 func main() {

--- a/examples/options_shortcut_example.go
+++ b/examples/options_shortcut_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt.go"
+	"github.com/docopt/docopt-go"
 )
 
 func main() {

--- a/examples/quick_example.go
+++ b/examples/quick_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt.go"
+	"github.com/docopt/docopt-go"
 )
 
 func main() {

--- a/examples/type_assert_example.go
+++ b/examples/type_assert_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt.go"
+	"github.com/docopt/docopt-go"
 )
 
 func main() {


### PR DESCRIPTION
After renaming the **docopt.go** GitHub project to **docopt-go**
and back again, the redirect remains. So it is now possible to
`go get github.com/docopt/docopt-go`.

This updates all imports and other references to the downloadable
Go package to **docopt-go** while keeping the GitHub project name as
**docopt.go**.

Fixes #2.
