### PR TITLE
tests(ci): add travis-ci.org config file for unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+# Travis CI (http://travis-ci.org/) is a continuous integration
+# service for open source projects. This file configures it
+# to run unit tests for docopt-go.
+
+language: go
+
+go:
+    - 1.1.2
+    - 1.2.1
+    - tip
+
+install: go get -d -v ./... && go build -v .
+
+script: go test -v .

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 docopt.go
 =========
 
+[![Build Status](https://travis-ci.org/docopt/docopt-go.svg?branch=master)](https://travis-ci.org/docopt/docopt-go)
+
 Golang implementation of [docopt](http://docopt.org/) 0.6.1+fix
 
 ## Installation


### PR DESCRIPTION
The .travis.yml file tells the continuous integration server to
build against the last 2 bugfix versions of Go, as well as the
in-development 1.3 version. It modifies the default "install:"
and "script:" commands so that docopt-go/examples isn't included.

The README.md file was also changed to show a build status badge.
