### PR TITLE
Accept -v to print version

### DIFF
--- a/docopt.go
+++ b/docopt.go
@@ -548,7 +548,7 @@ func extras(help bool, version string, options patternList, doc string) string {
 	}
 	if version != "" {
 		for _, o := range options {
-			if (o.name == "--version") && o.value == true {
+			if (o.name == "-v" || o.name == "--version") && o.value == true {
 				return version
 			}
 		}


### PR DESCRIPTION
The python version of this accepts -v as well as --version to print version. I assume that the golang version should accept -v as well.