### PR TITLE
add Bind() API

### DIFF
--- a/docopt.go
+++ b/docopt.go
@@ -66,6 +66,81 @@ func Parse(doc string, argv []string, help bool, version string,
 	return args, err
 }
 
+/*
+Bind binds `args` values to `opt`.
+
+`opt` must be pointer to struct, it returns error if `opt` is not pointer to struct.
+`args` will mapped to each exported struct field of `opt`. Examples:
+
+  // Field is ignored by Bind.
+  Field int `docopt:"-"`
+
+  // Field mapped from key "--help".
+  Field int `docopt:"--help"`
+
+  // Field mapped from key "-h".
+  Field int `docopt:"-h"`
+
+  // Field mapped from key "--field".
+  Field int
+
+  // F mapped from key "-f"
+  F int
+*/
+func Bind(opt interface{}, args map[string]interface{}) error {
+	value := reflect.ValueOf(opt)
+	if value.Kind() != reflect.Ptr {
+		return newError("'opt' argument is not pointer to struct type")
+	}
+	for value.Kind() == reflect.Ptr {
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Struct {
+		return newError("'opt' argument is not pointer to struct type")
+	}
+	typ := value.Type()
+	indexMap := make(map[string]int)
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if isUnexportedField(field) || field.Anonymous {
+			continue
+		}
+		tag := field.Tag.Get("docopt")
+		if tag == "" {
+			key := strings.ToLower(field.Name)
+			if len(field.Name) == 1 {
+				key = "-" + key
+			} else {
+				key = "--" + key
+			}
+			indexMap[key] = i
+			continue
+		}
+		for _, t := range strings.Split(tag, ",") {
+			indexMap[t] = i
+		}
+	}
+	for k, v := range args {
+		i, ok := indexMap[k]
+		if !ok {
+			return newError("mapping of \"%s\" is not found in given struct, or an unexported field", k)
+		}
+		field := value.Field(i)
+		if field.Interface() != reflect.Zero(field.Type()).Interface() {
+			continue
+		}
+		val := reflect.ValueOf(v)
+		if !val.Type().AssignableTo(field.Type()) {
+			return newError("value of '%s' is not assignable to '%s' field", k, value.Type().Field(i).Name)
+		}
+		if !field.CanSet() {
+			return newError("'%s' field cannot be set", value.Type().Field(i).Name)
+		}
+		field.Set(val)
+	}
+	return nil
+}
+
 // parse and return a map of args, output and all errors
 func parse(doc string, argv []string, help bool, version string, optionsFirst bool) (args map[string]interface{}, output string, err error) {
 	if argv == nil && len(os.Args) > 1 {
@@ -1236,4 +1311,16 @@ func isStringUppercase(s string) bool {
 		}
 	}
 	return false
+}
+
+/*
+isUnexportedField returns whether the field is unexported.
+
+isUnexportedField is to avoid the bug in versions older than Go1.3.
+See following links:
+  https://code.google.com/p/go/issues/detail?id=7247
+  http://golang.org/ref/spec#Exported_identifiers
+*/
+func isUnexportedField(field reflect.StructField) bool {
+	return !(field.PkgPath == "" && unicode.IsUpper(rune(field.Name[0])))
 }

--- a/docopt_test.go
+++ b/docopt_test.go
@@ -1432,6 +1432,58 @@ func TestFileTestcases(t *testing.T) {
 	}
 }
 
+func TestBind(t *testing.T) {
+	const usage = "Usage: prog [-h|--help] [-v] [-f] <command>"
+	for i, c := range []struct {
+		argv   []string
+		expect testoption
+	}{
+		{[]string{"-v", "test_cmd"}, testoption{
+			Command: "test_cmd",
+			Help:    false,
+			Verbose: true,
+			F:       false,
+		}},
+		{[]string{"-h", "test_cmd"}, testoption{
+			Command: "test_cmd",
+			Help:    true,
+			Verbose: false,
+			F:       false,
+		}},
+		{[]string{"--help", "test_cmd"}, testoption{
+			Command: "test_cmd",
+			Help:    true,
+			Verbose: false,
+			F:       false,
+		}},
+		{[]string{"-f", "test_cmd"}, testoption{
+			Command: "test_cmd",
+			Help:    false,
+			Verbose: false,
+			F:       true,
+		}},
+	} {
+		result := testoption{}
+		v, err := Parse(usage, c.argv, false, "", false, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := Bind(&result, v); err != nil {
+			t.Fatal(err)
+		}
+		if reflect.DeepEqual(result, c.expect) != true {
+			t.Error("testcase:", i, "result:", result, "expect:", c.expect)
+		}
+	}
+}
+
+type testoption struct {
+	Command string `docopt:"<command>"`
+	Help    bool   `docopt:"-h,--help"`
+	Verbose bool   `docopt:"-v"`
+	F       bool
+}
+
 type testcase struct {
 	id        int
 	doc       string


### PR DESCRIPTION
Currently, `Parse()` returns `map[string]interface{}`. It's inconvenience because it needs to do type assertion when using.
So I added `Bind()` API in order to relieves its burden.

Usage:

``` go
var option struct {
    Command string `docopt:"<command>"`
    Verbose bool   `docopt:"--verbose"`
    Other   string
}

var usage = `...`

func main() {
    args, _ := docopt.Parse(usage, nil, false, "", false)
    if err := docopt.Bind(&option, args); err != nil {
        log.Fatal(err)
    }
    fmt.Println(option)
}
```

Also this pull request is one solution of #4.
