### PR TITLE
[godoc.org] fix typo in `go get` command

### DIFF
--- a/docopt.go
+++ b/docopt.go
@@ -7,7 +7,7 @@ Package docopt parses command-line arguments based on a help message.
 ⚠ Use the alias “docopt-go”:
 	import "github.com/docopt/docopt-go"
 or
-	$ go get github.com/github/docopt-go
+	$ go get github.com/docopt/docopt-go
 */
 package docopt
 


### PR DESCRIPTION
Fixes minor error in comments and therefore [auto-generated godoc](https://godoc.org/github.com/docopt/docopt.go) regarding the `go get` command.
