### PR TITLE
chore(ci): stop testing golang "tip" since "go vet|cover" broke

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,25 +5,24 @@
 language: go
 
 go:
-    - 1.2.2
+    - 1.2
     - 1.3
-    - tip
 
 matrix:
     fast_finish: true
 
 before_install:
     - go get code.google.com/p/go.tools/cmd/vet
-    - go get -v github.com/golang/lint/golint
-    - go get -v code.google.com/p/go.tools/cmd/cover
-    - go get -v github.com/mattn/goveralls
+    - go get code.google.com/p/go.tools/cmd/cover
+    - go get github.com/golang/lint/golint
+    - go get github.com/mattn/goveralls
 
 install:
     - go get -d -v ./... && go build -v ./...
 
 script:
     - go vet -x ./...
-    - $HOME/gopath/bin/golint .
+    - $HOME/gopath/bin/golint ./...
     - go test -v ./...
     - go test -covermode=count -coverprofile=profile.cov .
 


### PR DESCRIPTION
Go 1.2 and 1.3 require this command to install "go vet":
  `go get code.google.com/p/go.tools/cmd/vet`
Go "tip" in Travis-CI currently requires this command:
  `go get golang.org/x/tools/cmd/vet`

Neither is happy with the other's package path, so let's not worry about testing golang "tip" for now.
