### PR TITLE
Changed the usage printing to stderr if it is not from -h or --help

### DIFF
--- a/docopt.go
+++ b/docopt.go
@@ -52,7 +52,7 @@ func Parse(doc string, argv []string, help bool, version string,
 	args, output, err := parse(doc, argv, help, version, optionsFirst)
 	if _, ok := err.(*UserError); ok {
 		// the user gave us bad input
-		fmt.Println(output)
+		fmt.Fprintln(os.Stderr, output)
 		if exitOk {
 			os.Exit(1)
 		}


### PR DESCRIPTION
Unless a usage message is requested, it should be printed to `stderr` instead of `stdout`.
This would make it consistent with Python's `docopt`: (the highlighting indicates a `grep` match)
![screen shot 2014-12-11 at 1 47 49 pm](https://cloud.githubusercontent.com/assets/1399455/5403572/f794f8e4-8142-11e4-98cb-d777e78a6b3b.png)
