### PR TITLE
Add a more helpful error message when unkown options are encountered

### DIFF
--- a/docopt.go
+++ b/docopt.go
@@ -181,7 +181,15 @@ func parse(doc string, argv []string, help bool, version string, optionsFirst bo
 		return
 	}
 
-	err = newUserError("")
+	if len(*left) > 0 {
+		var left_names []string
+		for _, l := range(*left) {
+			left_names = append(left_names, l.name)
+		}
+		err = newUserError(fmt.Sprintf("Unknown option(s): %s", strings.Join(left_names, ", ")))
+	} else {
+		err = newUserError("")
+	}
 	output = handleError(err, usage)
 	return
 }


### PR DESCRIPTION
When there is a bad option, docopt-go silently prints the usage and gives no indication of which option(s) it didn't like. It's very confusing when a program with a lot of options has a command line with one of them misspelled.

This patch complains about unknown options instead of silently printing the usage.
