### PR TITLE
Fix add command in the fake-git example

### DIFF
--- a/examples/fake-git/fakegit.go
+++ b/examples/fake-git/fakegit.go
@@ -100,7 +100,7 @@ options:
 	--ignore-missing     check if - even missing - files are ignored in dry run
 `
 
-	args, _ := docopt.ParseDoc(usage)
+	args, _ := docopt.ParseArgs(usage, argv, "")
 	fmt.Println(args)
 	return
 }


### PR DESCRIPTION
The argv constructed from the parent command should be used for argument parsing.