### PR TITLE
Update to use `docopt.go` import which should be ok since Go 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ language: go
 go:
     - 1.14
     - 1.15
+    - 1.16
+    - 1.17    
     - tip
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 # Travis CI (http://travis-ci.org/) is a continuous integration
 # service for open source projects. This file configures it
-# to run unit tests for docopt-go.
+# to run unit tests for docopt.go.
 
 language: go
 
 go:
-    - 1.4
-    - 1.5
-    - 1.6
-    - 1.7
-    - 1.8
-    - 1.9
+    - 1.14
+    - 1.15
     - tip
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-docopt-go
+docopt.go
 =========
 
 [![Build Status](https://travis-ci.org/docopt/docopt.go.svg?branch=master)](https://travis-ci.org/docopt/docopt.go)
@@ -14,7 +14,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt-go"
+	"github.com/docopt/docopt.go"
 )
 
 func main() {
@@ -44,16 +44,10 @@ Options:
 
 ## Installation
 
-⚠ Use the alias "docopt-go". To use docopt in your Go code:
-
-```go
-import "github.com/docopt/docopt-go"
-```
-
 To install docopt in your `$GOPATH`:
 
 ```console
-$ go get github.com/docopt/docopt-go
+$ go get github.com/docopt/docopt.go
 ```
 
 ## API
@@ -103,7 +97,7 @@ var config struct {
 opts.Bind(&config)
 ```
 
-More documentation is available at [godoc.org](https://godoc.org/github.com/docopt/docopt-go).
+More documentation is available at [godoc.org](https://pkg.go.dev/github.com/docopt/docopt.go).
 
 ## Unit Testing
 

--- a/examples/arguments/arguments.go
+++ b/examples/arguments/arguments.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt-go"
+	"github.com/docopt/docopt.go"
 )
 
 var usage = `Usage: arguments [-vqrh] [FILE] ...

--- a/examples/arguments/arguments_test.go
+++ b/examples/arguments/arguments_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/docopt/docopt-go/examples"
+	"github.com/docopt/docopt.go/examples"
 )
 
 func Example() {

--- a/examples/calculator/calculator.go
+++ b/examples/calculator/calculator.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt-go"
+	"github.com/docopt/docopt.go"
 )
 
 var usage = `Not a serious example.

--- a/examples/calculator/calculator_test.go
+++ b/examples/calculator/calculator_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/docopt/docopt-go/examples"
+	"github.com/docopt/docopt.go/examples"
 )
 
 func Example() {

--- a/examples/config_file/config_file.go
+++ b/examples/config_file/config_file.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/docopt/docopt-go"
+	"github.com/docopt/docopt.go"
 	"strings"
 )
 

--- a/examples/counted/counted.go
+++ b/examples/counted/counted.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt-go"
+	"github.com/docopt/docopt.go"
 )
 
 var usage = `Usage: counted --help

--- a/examples/counted/counted_test.go
+++ b/examples/counted/counted_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/docopt/docopt-go/examples"
+	"github.com/docopt/docopt.go/examples"
 )
 
 func Example() {

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/docopt/docopt-go"
+	"github.com/docopt/docopt.go"
 )
 
 // TestUsage is a helper used to test the output from the examples in this folder.

--- a/examples/fake-git/branch/git_branch.go
+++ b/examples/fake-git/branch/git_branch.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt-go"
+	"github.com/docopt/docopt.go"
 )
 
 func main() {

--- a/examples/fake-git/checkout/git_checkout.go
+++ b/examples/fake-git/checkout/git_checkout.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt-go"
+	"github.com/docopt/docopt.go"
 )
 
 func main() {

--- a/examples/fake-git/clone/git_clone.go
+++ b/examples/fake-git/clone/git_clone.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt-go"
+	"github.com/docopt/docopt.go"
 )
 
 func main() {

--- a/examples/fake-git/fakegit.go
+++ b/examples/fake-git/fakegit.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt-go"
+	"github.com/docopt/docopt.go"
 	"os"
 	"os/exec"
 )

--- a/examples/fake-git/push/git_push.go
+++ b/examples/fake-git/push/git_push.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt-go"
+	"github.com/docopt/docopt.go"
 )
 
 func main() {

--- a/examples/fake-git/remote/git_remote.go
+++ b/examples/fake-git/remote/git_remote.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt-go"
+	"github.com/docopt/docopt.go"
 )
 
 func main() {

--- a/examples/naval_fate/naval_fate.go
+++ b/examples/naval_fate/naval_fate.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt-go"
+	"github.com/docopt/docopt.go"
 )
 
 func main() {

--- a/examples/odd_even/odd_even.go
+++ b/examples/odd_even/odd_even.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt-go"
+	"github.com/docopt/docopt.go"
 )
 
 func main() {

--- a/examples/options/options.go
+++ b/examples/options/options.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt-go"
+	"github.com/docopt/docopt.go"
 )
 
 func main() {

--- a/examples/options_shortcut/options_shortcut.go
+++ b/examples/options_shortcut/options_shortcut.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt-go"
+	"github.com/docopt/docopt.go"
 )
 
 func main() {

--- a/examples/quick/quick.go
+++ b/examples/quick/quick.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt-go"
+	"github.com/docopt/docopt.go"
 )
 
 func main() {

--- a/examples/type_assert/type_assert.go
+++ b/examples/type_assert/type_assert.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt-go"
+	"github.com/docopt/docopt.go"
 )
 
 func main() {

--- a/examples/unit_test/unit_test.go
+++ b/examples/unit_test/unit_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/docopt/docopt-go"
+	"github.com/docopt/docopt.go"
 	"reflect"
 	"testing"
 )


### PR DESCRIPTION
Updated the repository to use `github.com/docopt/docopt.go` which since version Go 1.13 should work ok with Go modules (I know because other project I help maintain `nats.go` was one of the first projects ending with `.go` being able to use this approach without issues 😅 )

Signed-off-by: Waldemar Quevedo <wally@synadia.com>